### PR TITLE
Add TI descriptions

### DIFF
--- a/content/twitch/twitch-integration/acid_trap.md
+++ b/content/twitch/twitch-integration/acid_trap.md
@@ -1,0 +1,10 @@
+---
+title: 'ACID??'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Spawns a big [circle of](https://noita.wiki.gg/wiki/Circle_of_%28Material%29) deadly acid.
+
+If acid has been [fungal shifted](https://noita.wiki.gg/wiki/Fungal_Reality_Shift) away (i.e. with Tripping Balls), it is likely to be harmless instead.

--- a/content/twitch/twitch-integration/angry_big_steve.md
+++ b/content/twitch/twitch-integration/angry_big_steve.md
@@ -1,0 +1,10 @@
+---
+title: 'Angry BIG Steve'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Spawns [Scott](https://noita.wiki.gg/wiki/Skoude), the bigger, stronger version of Steve. Eats through terrain and can chase the player between levels.
+
+If [Steve](https://noita.wiki.gg/wiki/Stevari) has not been spawned yet, Scott may anger the gods and spawn Steve by eating through the holy mountain.

--- a/content/twitch/twitch-integration/angry_steve.md
+++ b/content/twitch/twitch-integration/angry_steve.md
@@ -1,0 +1,8 @@
+---
+title: 'Angry Steve'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Spawns [Steve](https://noita.wiki.gg/wiki/Stevari), who will attack the player unless they have [Peace with Gods](https://noita.wiki.gg/wiki/Peace_with_Gods).

--- a/content/twitch/twitch-integration/big_confuse.md
+++ b/content/twitch/twitch-integration/big_confuse.md
@@ -1,0 +1,8 @@
+---
+title: 'Big Confuse'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Inverts left/right controls for a while, like [Flummoxium](https://noita.wiki.gg/wiki/Flummoxium).

--- a/content/twitch/twitch-integration/big_worm.md
+++ b/content/twitch/twitch-integration/big_worm.md
@@ -1,0 +1,10 @@
+---
+title: 'Big Worm'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Summons a [giant worm](https://noita.wiki.gg/wiki/J%C3%A4ttimato). It digs through terrain and does melee damage.
+
+Will not cause direct damage to the player with [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity).

--- a/content/twitch/twitch-integration/biggest_worm.md
+++ b/content/twitch/twitch-integration/biggest_worm.md
@@ -1,0 +1,10 @@
+---
+title: 'Biggest Worm'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Spawns a [Hell Worm](https://noita.wiki.gg/wiki/Helvetinmato). The worm will eat through any material and can target the player.
+
+Hell Worms bleed lava.

--- a/content/twitch/twitch-integration/bitter_perks.md
+++ b/content/twitch/twitch-integration/bitter_perks.md
@@ -1,0 +1,12 @@
+---
+title: 'Bitter perks'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Surrounds perks in the next Holy Mountain with acid, enclosed in glass.
+
+To take a perk, the player has to break the glass to get rid of the acid first. The acid can eat through the brickwork and anger the gods.
+
+If a [fungal shift](https://noita.wiki.gg/wiki/Fungal_Reality_Shift) (e.g. from Tripping Balls) has removed acid, this option will likely be a lot less dangerous.

--- a/content/twitch/twitch-integration/blindness.md
+++ b/content/twitch/twitch-integration/blindness.md
@@ -1,0 +1,8 @@
+---
+title: 'Blindness'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Causes the Blinded status effect, similar to the [Master of Blinding](https://noita.wiki.gg/wiki/Sokaisunmestari)'s attack, but with a reduced duration.

--- a/content/twitch/twitch-integration/block_exit.md
+++ b/content/twitch/twitch-integration/block_exit.md
@@ -1,0 +1,8 @@
+---
+title: 'Block Exit'
+date: 2024-07-01T02:12:55+12:00
+type: docs
+draft: false
+---
+
+Blocks each portal at the end of the biome, either with a wooden platform, or with a pile of rubble, explosives, and Hiisi enemies.

--- a/content/twitch/twitch-integration/bloody_mess.md
+++ b/content/twitch/twitch-integration/bloody_mess.md
@@ -1,0 +1,12 @@
+---
+title: 'Bloody Mess'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Transforms all materials in a circle around the player into blood.
+
+If a [Fungal Reality Shift](https://noita.wiki.gg/wiki/Fungal_Reality_Shift) (e.g. from Tripping Balls) has transformed blood into a harmful material, this may be dangerous to the player.
+
+If a source of electricity is nearby, the player may be [electrocuted](https://noita.wiki.gg/wiki/Damage_Types#Electricity_Damage) if they do not have [Electricity Immunity](https://noita.wiki.gg/wiki/Electricity_Immunity).

--- a/content/twitch/twitch-integration/bomb_rush.md
+++ b/content/twitch/twitch-integration/bomb_rush.md
@@ -1,0 +1,8 @@
+---
+title: 'Bomb Rush'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Causes random bombs to spawn around the player every few seconds, with a large countdown on screen for each wave of bombs.

--- a/content/twitch/twitch-integration/broken_trap.md
+++ b/content/twitch/twitch-integration/broken_trap.md
@@ -1,0 +1,8 @@
+---
+title: 'Broken Trap'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns an [acid trap](https://noita.wiki.gg/wiki/Traps) box (as seen in the Mines). When damaged, it will create a [Circle of Acid](https://noita.wiki.gg/wiki/Circle_of_%28Material%29), which is dangerous to the player.

--- a/content/twitch/twitch-integration/buoyancy.md
+++ b/content/twitch/twitch-integration/buoyancy.md
@@ -1,0 +1,8 @@
+---
+title: 'Buoyancy'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a [Circle of Buoyancy](https://noita.wiki.gg/wiki/Circle_of_Buoyancy) on the player, making it difficult to move.

--- a/content/twitch/twitch-integration/ceasefire.md
+++ b/content/twitch/twitch-integration/ceasefire.md
@@ -1,0 +1,7 @@
+---
+title: 'Ceasefire '
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+

--- a/content/twitch/twitch-integration/cheesy.md
+++ b/content/twitch/twitch-integration/cheesy.md
@@ -1,0 +1,12 @@
+---
+title: 'Cheese'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Turns everything in a large radius around the player into cheese.
+
+Explosives will be detonated, and portals will be deactivated if near enough (because the teleportatium powering them gets turned to cheese).
+
+If near a holy mountain, the brickwork turning to cheese will anger the gods, causing [Steve](https://noita.wiki.gg/wiki/Stevari) to spawn in future holy mountains.

--- a/content/twitch/twitch-integration/chests.md
+++ b/content/twitch/twitch-integration/chests.md
@@ -1,0 +1,8 @@
+---
+title: 'Chests'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns 5 [chest mimics](https://noita.wiki.gg/wiki/Matkija) and 1 [chest](https://noita.wiki.gg/wiki/Treasure_Chest).

--- a/content/twitch/twitch-integration/chonky.md
+++ b/content/twitch/twitch-integration/chonky.md
@@ -1,0 +1,8 @@
+---
+title: 'CHONKY'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Each time the player lands on the ground, the ground under them is partially destroyed.

--- a/content/twitch/twitch-integration/cluttered_shop.md
+++ b/content/twitch/twitch-integration/cluttered_shop.md
@@ -1,0 +1,8 @@
+---
+title: 'Cluttered shop'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Creates a pile of rubbish in the next Holy Mountain shop, making it more difficult to buy spells/wands.

--- a/content/twitch/twitch-integration/cold_weather.md
+++ b/content/twitch/twitch-integration/cold_weather.md
@@ -1,0 +1,8 @@
+---
+title: 'Cold Weather'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a large amount of [Freezing Vapour](https://noita.wiki.gg/wiki/Freezing_Vapour) above the player, which causes damage on contact.

--- a/content/twitch/twitch-integration/conga_bad_water.md
+++ b/content/twitch/twitch-integration/conga_bad_water.md
@@ -1,0 +1,10 @@
+---
+title: 'Poisoned Water'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Causes water to damage the player on contact. Water stains do not cause damage.
+
+Frozen Prison or Swimming Pool are dangerous with this, since they surround the player in water.

--- a/content/twitch/twitch-integration/conga_blackhole_boomerang.md
+++ b/content/twitch/twitch-integration/conga_blackhole_boomerang.md
@@ -1,0 +1,12 @@
+---
+title: 'Homing Blackhole'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a large damaging black hole that follows the player. It pulls in objects and creatures (including the player), and can fling loose debris, causing physics damage.
+
+Can be deadly if the player is cornered. Other spells (i.e. regular [black holes](https://noita.wiki.gg/wiki/Black_Hole)) and items (i.e. [Kuu](https://noita.wiki.gg/wiki/Kuu)) are capable of pulling the black hole in.
+
+If the black hole loses its homing target, it will start to move in random directions.

--- a/content/twitch/twitch-integration/conga_delusional.md
+++ b/content/twitch/twitch-integration/conga_delusional.md
@@ -1,0 +1,21 @@
+---
+title: 'Delusional'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Periodically spawns fake enemies. The enemies do not deal damage and cannot be hit or stained.
+
+Possible enemies:
+- [Bat](https://noita.wiki.gg/wiki/Lepakko)
+- [Firefly](https://noita.wiki.gg/wiki/Tulik%C3%A4rp%C3%A4nen)
+- [Big Toad](https://noita.wiki.gg/wiki/J%C3%A4ttikonna)
+- [Robo-Cop](https://noita.wiki.gg/wiki/Robottikytt%C3%A4)
+- [Swampling](https://noita.wiki.gg/wiki/M%C3%A4rki%C3%A4inen)
+- [Shotgun Hiisi](https://noita.wiki.gg/wiki/M%C3%A4rki%C3%A4inen)
+- [Skull Fly](https://noita.wiki.gg/wiki/Kallok%C3%A4rp%C3%A4nen)
+- [Skull Rat](https://noita.wiki.gg/wiki/Kallorotta)
+- [Hiisi Sniper](https://noita.wiki.gg/wiki/Snipuhiisi)
+- [Master of Polymorphing](https://noita.wiki.gg/wiki/Muodonmuutosmestari)
+- [Hound](https://noita.wiki.gg/wiki/Hurtta)

--- a/content/twitch/twitch-integration/conga_derandomized_projectiles.md
+++ b/content/twitch/twitch-integration/conga_derandomized_projectiles.md
@@ -1,0 +1,17 @@
+---
+title: 'Derandomized Enemy Attacks'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Makes all enemies use the same attack, chosen at random.
+
+Can be especially powerful in early levels, where typical attacks are weak.
+
+Voting for it again while it is active will replace the current effect, choosing a new random attack.
+If the current attack is dangerous, it may be replaced with a more harmless attack.
+
+If the nearby enemies are powerful on their own, changing their attacks is likely to make them less dangerous.
+
+Derandomised attacks can range from very dangerous (e.g. [Circle of Acid](https://noita.wiki.gg/wiki/Circle_of_%28Material%29)) to very helpful (e.g. healing spells). Most of the time, the attacks are not helpful to the player (but may or may not be more harmful than default attacks).

--- a/content/twitch/twitch-integration/conga_forced_checkpoint.md
+++ b/content/twitch/twitch-integration/conga_forced_checkpoint.md
@@ -1,0 +1,10 @@
+---
+title: 'Forced Checkpoint'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Teleports the player to the last biome entrance, based on how far down they currently are.
+
+The final boss area is not included, so if selected during the boss fight, the player will be teleported to the entrance of the [Temple of the Art](https://noita.wiki.gg/wiki/Temple_of_the_Art).

--- a/content/twitch/twitch-integration/conga_monstrous_drink.md
+++ b/content/twitch/twitch-integration/conga_monstrous_drink.md
@@ -1,0 +1,12 @@
+---
+title: 'Monstrous Drink'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Adds some Monstrous Powder to all of the player's potions. Monstrous Powder spawns [bridge bosses](https://noita.wiki.gg/wiki/Sauvojen_tuntija) when poured.
+
+Since it can be countered easily by drinking some of the potion, it is usually only dangerous when forgotten or not noticed.
+
+If the player has a water flask and catches fire, they have a good chance of unwittingly spawning bosses by pouring the flask.

--- a/content/twitch/twitch-integration/conga_refresh_mimic.md
+++ b/content/twitch/twitch-integration/conga_refresh_mimic.md
@@ -1,0 +1,13 @@
+---
+title: 'The Rarest Mimic'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Replaces either the heart or the spell refresher in the next Holy Mountain with a mimic version.
+
+- [Heart mimic](https://noita.wiki.gg/wiki/Pahan_muisto)
+- [Refresh mimic](https://noita.wiki.gg/wiki/Valhe)
+
+The mimics will attempt to bite the player, dealing melee damage. They will not do damage if the player has [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity). However, the lack of healing or refreshed spell charges can still cause problems for the player.

--- a/content/twitch/twitch-integration/conga_spells_to_worms.md
+++ b/content/twitch/twitch-integration/conga_spells_to_worms.md
@@ -1,0 +1,14 @@
+---
+title: 'Spells 2 Worms'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Turns all spells into [Worm Launcher](https://noita.wiki.gg/wiki/Worm_Launcher) projectiles for a time.
+
+Worms from Worm Launcher boomerang back to the player, dealing melee damage. Particularly dangerous with rapid-fire wands.
+
+Since worms do melee damage, they will be harmless with [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity).
+
+If the player has [Levitation Trail](https://noita.wiki.gg/wiki/Levitation_Trail), each particle of the trail is transformed into a worm, making it quite deadly.

--- a/content/twitch/twitch-integration/conga_steal_wand.md
+++ b/content/twitch/twitch-integration/conga_steal_wand.md
@@ -1,0 +1,14 @@
+---
+title: 'Possess Wand'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Attempts to possess the currently held wand, which will then fire at the player by itself. It works the same way as a [Taikasauva](https://noita.wiki.gg/wiki/Taikasauva).
+
+Particularly dangerous with rapid-fire or high-damage wands. Does nothing if the player is not holding a wand at the moment it activates.
+
+A visual warning is shown shortly before it activates, which allows the player to quickly switch to an item to avoid it.
+
+The same visual warning is used for Tripping Balls, as a way of countering reflexes (switching to a flask during a fungal shift has a good chance of causing the contents of the flask to be transformed, which is usually undesirable for the player).

--- a/content/twitch/twitch-integration/conga_teleport_nullification.md
+++ b/content/twitch/twitch-integration/conga_teleport_nullification.md
@@ -1,0 +1,22 @@
+---
+title: 'Teleport Nullification'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Prevents most kinds of teleportation, not including holy mountain portals.
+
+Spells:
+- [Teleport Bolt](https://noita.wiki.gg/wiki/Teleport_Bolt)
+- [Small Teleport Bolt](https://noita.wiki.gg/wiki/Teleport_Bolt)
+- [Return](https://noita.wiki.gg/wiki/Return)
+- [Swapper](https://noita.wiki.gg/wiki/Swapper)
+
+Perks:
+- [Teleportitis](https://noita.wiki.gg/wiki/Teleportitis)
+- [Teleportitis Dodge](https://noita.wiki.gg/wiki/Teleportitis_Dodge)
+
+Other:
+- [Swapper mage](https://noita.wiki.gg/wiki/Vaihdosmestari)
+- [RGB portals](https://noita.wiki.gg/wiki/Mod:Apotheosis/Portals) from the [Apotheosis](https://noita.wiki.gg/wiki/Mod:Apotheosis) mod

--- a/content/twitch/twitch-integration/conga_weebpocalypse.md
+++ b/content/twitch/twitch-integration/conga_weebpocalypse.md
@@ -1,0 +1,10 @@
+---
+title: 'Weebpocalypse'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Transforms all nearby enemies into [tentaclers](https://noita.wiki.gg/wiki/Turso), or the [small version](https://noita.wiki.gg/wiki/Pikkuturso) of them.
+
+Dangerous to the player because of the risk of freeze melee. Mostly harmless with [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity). Being frozen can still cause the player to fall into something dangerous.

--- a/content/twitch/twitch-integration/couple_worms.md
+++ b/content/twitch/twitch-integration/couple_worms.md
@@ -1,0 +1,8 @@
+---
+title: 'A Couple Worms'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a couple regular-sized [worms](https://noita.wiki.gg/wiki/Mato).

--- a/content/twitch/twitch-integration/cut_health.md
+++ b/content/twitch/twitch-integration/cut_health.md
@@ -1,0 +1,14 @@
+---
+title: 'Take Damage'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Reduces the player's current HP by 25% using electric damage.
+
+The player will be briefly [Stunned](https://noita.wiki.gg/wiki/Status_Effects#Stunned), preventing them from doing anything for a moment.
+
+May cause the player to fall into something dangerous (e.g. lava) if they are levitating over it.
+
+[Electricity Immunity](https://noita.wiki.gg/wiki/Electricity_Immunity) prevents the player from being damaged or stunned.

--- a/content/twitch/twitch-integration/derandomize_enemy_waves.md
+++ b/content/twitch/twitch-integration/derandomize_enemy_waves.md
@@ -1,0 +1,10 @@
+---
+title: 'Derandomized enemies'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Chooses an enemy at random, and transforms all enemies into that enemy.
+
+Can be a dangerous combo with options that spawn enemies.

--- a/content/twitch/twitch-integration/dryspell.md
+++ b/content/twitch/twitch-integration/dryspell.md
@@ -1,0 +1,10 @@
+---
+title: 'Dryspell'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Removes all liquids in a small radius around the player. Also prevents stains, and stops fire from being put out.
+
+Since it is an ingestion-based status effect, vomiting will prematurely end the effect. Tripping Balls, for example, will end Dryspell.

--- a/content/twitch/twitch-integration/earthquake.md
+++ b/content/twitch/twitch-integration/earthquake.md
@@ -1,0 +1,10 @@
+---
+title: 'Earthquake!'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Exactly what it says. Falling debris is very dangerous to the player.
+
+If debris traps the player without killing them, options that remove terrain (Helpful Blackhole, Lava Pit, etc.) may free them.

--- a/content/twitch/twitch-integration/electrocution.md
+++ b/content/twitch/twitch-integration/electrocution.md
@@ -1,0 +1,12 @@
+---
+title: 'Electrocution'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Briefly electrocutes the player without directly causing damage. Often doesn't do much, but at the right moment it can end a run.
+
+Very dangerous when the player is over lava (e.g. from Lava Pit).
+
+Being electrocuted around enemies allows the enemies to attack without the player interfering for a moment.

--- a/content/twitch/twitch-integration/enemies_to_steve.md
+++ b/content/twitch/twitch-integration/enemies_to_steve.md
@@ -1,0 +1,10 @@
+---
+title: 'Steve gang'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Turns all nearby enemies into [Steve](https://noita.wiki.gg/wiki/Stevari) for a while.
+
+Usually quite dangerous. Groups of small enemies (such as [Hämis](https://noita.wiki.gg/wiki/H%C3%A4mis)) which are usually weak can easily create a deadly situation.

--- a/content/twitch/twitch-integration/enemy_shields.md
+++ b/content/twitch/twitch-integration/enemy_shields.md
@@ -1,0 +1,8 @@
+---
+title: 'Enemy Shields'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Gives enemies shields, similar to an [Energy Shield](https://noita.wiki.gg/wiki/Energy_Shield).

--- a/content/twitch/twitch-integration/event_horizon.md
+++ b/content/twitch/twitch-integration/event_horizon.md
@@ -1,0 +1,8 @@
+---
+title: 'Event Horizon'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns Giga Black Holes near the player. Causes a lot of damage if it hits the player. Loose debris can also hit the player.

--- a/content/twitch/twitch-integration/everyone_loves_larpa.md
+++ b/content/twitch/twitch-integration/everyone_loves_larpa.md
@@ -1,0 +1,10 @@
+---
+title: 'Everyone Loves Larpa'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Applies [Larpa](https://noita.wiki.gg/wiki/Larpa) effects to all projectiles (from both the player and enemies) for a time.
+
+Larpa modifiers create duplicates of projectiles. While it can make the player's attacks stronger, it also makes enemies stronger, and makes self-damaging spells (like bombs) more dangerous.

--- a/content/twitch/twitch-integration/explosives.md
+++ b/content/twitch/twitch-integration/explosives.md
@@ -1,0 +1,8 @@
+---
+title: 'Explosives'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns random explosives near the player. They will not explode by themselves, but can be set off by the player, enemies, or other effects.

--- a/content/twitch/twitch-integration/fire_trap.md
+++ b/content/twitch/twitch-integration/fire_trap.md
@@ -1,0 +1,10 @@
+---
+title: 'Fiery Circle'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns [Circle of Fire](https://noita.wiki.gg/wiki/Circle_of_%28Material%29) a few times.
+
+Can be dangerous on low health, or if Dryspell is currently active (since the player cannot put out fire, it can deal significant damage).

--- a/content/twitch/twitch-integration/foo.md
+++ b/content/twitch/twitch-integration/foo.md
@@ -1,0 +1,6 @@
+---
+title: 'Foo'
+date: 2024-07-01T02:20:05+12:00
+type: docs
+draft: true
+---

--- a/content/twitch/twitch-integration/gamba.md
+++ b/content/twitch/twitch-integration/gamba.md
@@ -1,0 +1,8 @@
+---
+title: 'Gamba'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Picks two random effects. Can be a dangerous combo, but can be useless or even helpful to the player.

--- a/content/twitch/twitch-integration/glue_curse.md
+++ b/content/twitch/twitch-integration/glue_curse.md
@@ -1,0 +1,10 @@
+---
+title: 'Glue Curse'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Causes the player to get glued in place whenever they take damage.
+
+Being unable to effectively dodge can cause the player to get glued further.

--- a/content/twitch/twitch-integration/green_crystal_trap.md
+++ b/content/twitch/twitch-integration/green_crystal_trap.md
@@ -1,0 +1,12 @@
+---
+title: 'Curse of the Temple'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Turns random circles of solid material near the player into Cursed Rock, and turns liquids into Poison.
+
+Can cause a lot of damage, and prevents digging using basic digging spells. Spells like Black Hole or Luminous Drill are required to dig through Cursed Rock if there are no other ways out.
+
+Can be very effective if the player is already trapped (e.g. from an earthquake).

--- a/content/twitch/twitch-integration/green_thumb.md
+++ b/content/twitch/twitch-integration/green_thumb.md
@@ -1,0 +1,8 @@
+---
+title: 'Green Thumb'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Periodically spawns growing vines near the player for a while. The vines have poison-filled fruit, similar to the '[wet soil](https://noita.wiki.gg/wiki/Biome_Modifiers#Wet_Soil_/_Plant_Infested)' biome modifier.

--- a/content/twitch/twitch-integration/grounded.md
+++ b/content/twitch/twitch-integration/grounded.md
@@ -1,0 +1,8 @@
+---
+title: 'Grounded'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Temporarily disables the player's levitation. It is still possible to jump a small height.

--- a/content/twitch/twitch-integration/haunted.md
+++ b/content/twitch/twitch-integration/haunted.md
@@ -1,0 +1,10 @@
+---
+title: 'Haunted!'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a ghost ([Houre](https://noita.wiki.gg/wiki/Houre)) that is not tethered to a crystal, and will slowly follow the player for a minute.
+
+Houre deals [curse damage](https://noita.wiki.gg/wiki/Damage_Types#Curse_Damage) when over the player. It can be destroyed with acid or physics damage.

--- a/content/twitch/twitch-integration/health_down.md
+++ b/content/twitch/twitch-integration/health_down.md
@@ -1,0 +1,8 @@
+---
+title: 'Health Down'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Reduces the maximum health of the player by 20%.

--- a/content/twitch/twitch-integration/helpful_black_hole.md
+++ b/content/twitch/twitch-integration/helpful_black_hole.md
@@ -1,0 +1,10 @@
+---
+title: 'Helpful Blackhole'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a Black Hole on the player, with a boomerang effect. The black hole itself does not damage the player.
+
+It can pull in nearby explosives or flasks, and can anger the gods if it destroys the [right part](https://noita.wiki.gg/wiki/File:Holy_mountain_triggers.png) of an intact holy mountain.

--- a/content/twitch/twitch-integration/hiisi_bastards.md
+++ b/content/twitch/twitch-integration/hiisi_bastards.md
@@ -1,0 +1,10 @@
+---
+title: 'Hiisi Bastards'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a bunch of [Hiisi](https://noita.wiki.gg/wiki/Hiisi).
+
+As with other options that spawn enemies, this can be a dangerous combo with options that modify enemies (e.g. Derandomized Enemies, Derandomized Enemy Attacks, Weebpocalypse, Steve Gang).

--- a/content/twitch/twitch-integration/holiday_chests.md
+++ b/content/twitch/twitch-integration/holiday_chests.md
@@ -1,0 +1,10 @@
+---
+title: 'Holiday Chests'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Adds a [Kuu](https://noita.wiki.gg/wiki/Kuu) to the next 3 chests. Selecting this option more than once adds to the number (e.g. selecting it twice results in 6 chests containing a Kuu).
+
+The Kuu will pull in nearby objects, which can sometimes be dangerous.

--- a/content/twitch/twitch-integration/hounds.md
+++ b/content/twitch/twitch-integration/hounds.md
@@ -1,0 +1,12 @@
+---
+title: 'Hounds'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns some [hounds](https://noita.wiki.gg/wiki/Hurtta) near the player.
+
+Hounds do melee damage, and so will be harmless if the player has [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity).
+
+As with other options that spawn enemies, this can be a dangerous combo with options that modify enemies (e.g. Derandomized Enemies, Derandomized Enemy Attacks, Weebpocalypse, Steve Gang).

--- a/content/twitch/twitch-integration/ice_cage.md
+++ b/content/twitch/twitch-integration/ice_cage.md
@@ -1,0 +1,10 @@
+---
+title: 'Frozen prison'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Creates a ring of ice around the player, filled with water.
+
+Especially dangerous with Poisoned Water, or if the player has no form of digging/teleportation whatsoever.

--- a/content/twitch/twitch-integration/jetpack_jamboree.md
+++ b/content/twitch/twitch-integration/jetpack_jamboree.md
@@ -1,0 +1,8 @@
+---
+title: 'Jetpack Jamboree'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Gives all enemies within a large radius jetpacks, so they can levitate (like the player).

--- a/content/twitch/twitch-integration/labyrinth.md
+++ b/content/twitch/twitch-integration/labyrinth.md
@@ -1,0 +1,7 @@
+---
+title: 'Labyrinth'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+

--- a/content/twitch/twitch-integration/lava_sea.md
+++ b/content/twitch/twitch-integration/lava_sea.md
@@ -1,0 +1,10 @@
+---
+title: 'Lava pit'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Creates a wide pool of lava in a glass container under the player. The area above the pool is cleared, detonating any explosives in the process.
+
+If lava has been [fungal shifted](https://noita.wiki.gg/wiki/Fungal_Reality_Shift) away (i.e. with Tripping Balls), it is likely to be harmless instead.

--- a/content/twitch/twitch-integration/loose_chunks.md
+++ b/content/twitch/twitch-integration/loose_chunks.md
@@ -1,0 +1,12 @@
+---
+title: 'Loose Chunks'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Periodically causes a small chunk of material near the player to crumble, in a similar way to [Earthquake Shot](https://noita.wiki.gg/wiki/Earthquake_Shot).
+
+If a chunk of loose material hits the player, it can do a lot of damage.
+
+Can be more dangerous with things that pull in the debris, like Helpful Blackhole.

--- a/content/twitch/twitch-integration/moist_mob.md
+++ b/content/twitch/twitch-integration/moist_mob.md
@@ -1,0 +1,12 @@
+---
+title: 'THE MOIST MOB'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns many frogs under the player. Frogs attack with melee damage.
+
+Frogs are harmless when the player has [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity).
+
+As with other options that spawn enemies, this can be a dangerous combo with options that modify enemies (e.g. Derandomized Enemies, Derandomized Enemy Attacks, Weebpocalypse, Steve Gang).

--- a/content/twitch/twitch-integration/moneyshot.md
+++ b/content/twitch/twitch-integration/moneyshot.md
@@ -1,0 +1,10 @@
+---
+title: 'Moneyshot'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Makes each shot from the player's wands cost 3 gold, and adds 0.4 damage to the shot.
+
+Rapid-fire wands can quickly deplete the player's gold.

--- a/content/twitch/twitch-integration/mountain_orb.md
+++ b/content/twitch/twitch-integration/mountain_orb.md
@@ -1,0 +1,10 @@
+---
+title: 'Add Orb'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Causes the player to pick up an [Orb of True Knowledge](https://noita.wiki.gg/wiki/Orb_of_True_Knowledge), which grants the player +25 extra max HP (or more with [Stronger Hearts](https://noita.wiki.gg/wiki/Stronger_Hearts)), and increases the difficulty of the final boss.
+
+With each orb, the boss will gain HP based on [scaling formula](https://noita.wiki.gg/wiki/Kolmisilm%C3%A4#Scaling), and can gain extra defences/attacks/resistances/immunities depending on the total orb count.

--- a/content/twitch/twitch-integration/nerf_wands.md
+++ b/content/twitch/twitch-integration/nerf_wands.md
@@ -1,0 +1,10 @@
+---
+title: 'Nerf Wands'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Randomly increases cast delay, recharge time, and/or spread, of some of the player's wands.
+
+Also increases the mana of the wands by a random amount.

--- a/content/twitch/twitch-integration/plaguee_rats.md
+++ b/content/twitch/twitch-integration/plaguee_rats.md
@@ -1,0 +1,8 @@
+---
+title: 'plaGUEE Rats'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns 20-30 [rats](https://noita.wiki.gg/wiki/Rotta), 10-20 [plague rats](https://noita.wiki.gg/wiki/Ruttorotta), and 1-2 [skull rats](https://noita.wiki.gg/wiki/Kallorotta).

--- a/content/twitch/twitch-integration/poltergeist.md
+++ b/content/twitch/twitch-integration/poltergeist.md
@@ -1,0 +1,8 @@
+---
+title: 'Poltergeist'
+date: 2024-07-01T02:12:56+12:00
+type: docs
+draft: false
+---
+
+Spawns a [player ghost](https://noita.wiki.gg/wiki/Kummitus) carrying a randomly-generated wand.

--- a/content/twitch/twitch-integration/rainy_day.md
+++ b/content/twitch/twitch-integration/rainy_day.md
@@ -1,0 +1,17 @@
+---
+title: 'Rainy Day'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a cloud that rains a random liquid.
+
+Possible liquids:
+- [Blood](https://noita.wiki.gg/wiki/Blood)
+- [Toxic Sludge](https://noita.wiki.gg/wiki/Toxic_Sludge)
+- [Water](https://noita.wiki.gg/wiki/Water)
+- [Slime](https://noita.wiki.gg/wiki/Slime)
+- [Pheromone](https://noita.wiki.gg/wiki/Pheromone)
+- [Acid](https://noita.wiki.gg/wiki/Acid)
+- [Lava](https://noita.wiki.gg/wiki/Lava)

--- a/content/twitch/twitch-integration/random_circle.md
+++ b/content/twitch/twitch-integration/random_circle.md
@@ -1,0 +1,24 @@
+---
+title: 'The Alchemic Circle'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a [circle of](https://noita.wiki.gg/wiki/Circle_of_%28Material%29) random liquids near the player.
+
+Possible liquids include:
+- [Void Liquid](https://noita.wiki.gg/wiki/Void_Liquid)
+- [Oil](https://noita.wiki.gg/wiki/Oil)
+- [Fire](https://noita.wiki.gg/wiki/Fire)
+- [Blood](https://noita.wiki.gg/wiki/Blood)
+- [Water](https://noita.wiki.gg/wiki/Water)
+- [Acid](https://noita.wiki.gg/wiki/Acid)
+- [Whiskey](https://noita.wiki.gg/wiki/Whiskey)
+- [Flummoxium](https://noita.wiki.gg/wiki/Flummoxium)
+- [Acceleratium](https://noita.wiki.gg/wiki/Acceleratium)
+- [Worm Pheromone](https://noita.wiki.gg/wiki/Worm_Pheromone)
+- [Ambrosia](https://noita.wiki.gg/wiki/Ambrosia)
+- [Concentrated Mana](https://noita.wiki.gg/wiki/Concentrated_Mana)
+- [Teleportatium](https://noita.wiki.gg/wiki/Teleportatium)
+- [Healthium](https://noita.wiki.gg/wiki/Healthium)

--- a/content/twitch/twitch-integration/random_flask.md
+++ b/content/twitch/twitch-integration/random_flask.md
@@ -1,0 +1,29 @@
+---
+title: 'Random Flask'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a flask containing a random liquid at the player's current position.
+
+75% chance of spawning certain [magic liquids](https://noita.wiki.gg/wiki/Category:Materials_tagged_with_magic_liquid):
+- [Teleportatium](https://noita.wiki.gg/wiki/Teleportatium)
+- [Polymorphine](https://noita.wiki.gg/wiki/Polymorphine)
+- [Chaotic Polymorphine](https://noita.wiki.gg/wiki/Chaotic_Polymorphine)
+- [Berserkium](https://noita.wiki.gg/wiki/Berserkium)
+- [Pheromone](https://noita.wiki.gg/wiki/Pheromone)
+- [Invisiblium](https://noita.wiki.gg/wiki/Invisiblium)
+
+25% chance of spawning a regular liquid:
+- [Lava](https://noita.wiki.gg/wiki/Lava)
+- [Water](https://noita.wiki.gg/wiki/Water)
+- [Blood](https://noita.wiki.gg/wiki/Blood)
+- [Whiskey](https://noita.wiki.gg/wiki/Whiskey)
+- [Oil](https://noita.wiki.gg/wiki/Oil)
+- [Slime](https://noita.wiki.gg/wiki/Slime)
+- [Acid](https://noita.wiki.gg/wiki/Acid)
+- [Toxic Sludge](https://noita.wiki.gg/wiki/Toxic_Sludge)
+- [Unstable Gunpowder](https://noita.wiki.gg/wiki/Gunpowder)
+- [Liquid Fire](https://noita.wiki.gg/wiki/Liquid_Fire)
+- [Freezing Liquid](https://noita.wiki.gg/wiki/Freezing_Liquid)

--- a/content/twitch/twitch-integration/random_perk.md
+++ b/content/twitch/twitch-integration/random_perk.md
@@ -1,0 +1,8 @@
+---
+title: 'Random Perk'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Gives the player a random perk. Most perks are positive, but occasionally a negative perk is picked.

--- a/content/twitch/twitch-integration/random_teleport.md
+++ b/content/twitch/twitch-integration/random_teleport.md
@@ -1,0 +1,14 @@
+---
+title: 'Random Teleport'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Teleports the player in a random direction.
+
+Can be dangerous if the player is teleported into enemies or dangerous liquids (e.g. lava). Teleporting into lava is quite likely when in the final boss area, which has a large amount of lava above and below.
+
+If Teleport Beacon is active, the player will teleport to the beacon instead.
+
+If Teleport Rideshare is active, nearby enemies will be teleported along with the player.

--- a/content/twitch/twitch-integration/randomize_enemies.md
+++ b/content/twitch/twitch-integration/randomize_enemies.md
@@ -1,0 +1,8 @@
+---
+title: 'Random enemies'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Every 5 seconds, turns enemies around the player into random other enemies.

--- a/content/twitch/twitch-integration/rogue_black_hole.md
+++ b/content/twitch/twitch-integration/rogue_black_hole.md
@@ -1,0 +1,10 @@
+---
+title: 'Rogue Black Hole'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a Giga Black Hole, moving in a line towards the position the player was in at the moment it was spawned.
+
+Can damage the player if they can't move away in time. Can also generate dangerous debris.

--- a/content/twitch/twitch-integration/sanic_curse.md
+++ b/content/twitch/twitch-integration/sanic_curse.md
@@ -1,0 +1,8 @@
+---
+title: 'Sanic''s curse'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Sonic-like rings fly out of the player when they take damage, each containing some of the player's gold. The player has to collect the rings to regain their gold.

--- a/content/twitch/twitch-integration/sauna.md
+++ b/content/twitch/twitch-integration/sauna.md
@@ -1,0 +1,12 @@
+---
+title: 'Sauna'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Fills the area with [Steam](https://noita.wiki.gg/wiki/Steam).
+
+The player can start to [suffocate](https://noita.wiki.gg/wiki/Damage_Types#Suffocation_Damage) if they do not find air.
+
+The [Breathless](https://noita.wiki.gg/wiki/Breathless) perk (and the rare [water stone](https://noita.wiki.gg/wiki/Vuoksikivi)) will prevent suffocation.

--- a/content/twitch/twitch-integration/scale_damage.md
+++ b/content/twitch/twitch-integration/scale_damage.md
@@ -1,0 +1,8 @@
+---
+title: 'NG+ Damage'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Increases damage multipliers for the player, so they take more damage from everything for the rest of the run.

--- a/content/twitch/twitch-integration/scale_enemies.md
+++ b/content/twitch/twitch-integration/scale_enemies.md
@@ -1,0 +1,8 @@
+---
+title: 'NG+ Enemies'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Makes enemies harder to kill and attack faster for the rest of the run.

--- a/content/twitch/twitch-integration/secret_ending.md
+++ b/content/twitch/twitch-integration/secret_ending.md
@@ -1,0 +1,10 @@
+---
+title: 'Secret Ending'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a stationary black hole and an [Eldritch Portal](https://noita.wiki.gg/wiki/Eldritch_Portal).
+
+The tentacles from the Eldritch Portal can damage the player. The black hole can pull in nearby objects.

--- a/content/twitch/twitch-integration/shadowdragon.md
+++ b/content/twitch/twitch-integration/shadowdragon.md
@@ -1,0 +1,10 @@
+---
+title: 'Shadowdragon'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a ["Dragon"](https://noita.wiki.gg/wiki/Suomuhauki) with reduced bite damage.
+
+The dragon will despawn once it has damaged the player for 25% of their max HP, as long as the player's HP is below 50%.

--- a/content/twitch/twitch-integration/shift.md
+++ b/content/twitch/twitch-integration/shift.md
@@ -1,0 +1,16 @@
+---
+title: 'Tripping Balls'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Triggers a [Fungal Reality Shift](https://noita.wiki.gg/wiki/Fungal_Reality_Shift).
+
+If the player is holding a flask at the moment of the shift, there is a 75% chance the material in the flask will either be turned into something else, or something else will be turned into the material.
+
+A short visual warning is shown before the shift takes place. The same visual warning is used for Possess Wand, as a way of countering reflexes (switching to a wand when Possess Wand is about to take effect will cause the wand to be possessed).
+
+Take note of what gets shifted - if acid or lava gets shifted away, it will neutralise ACID?? and Lava Pit.
+
+Shifts have a 5 minute cooldown, so voting for it twice won't do anything unless it has been over 5 minutes.

--- a/content/twitch/twitch-integration/shrooms.md
+++ b/content/twitch/twitch-integration/shrooms.md
@@ -1,0 +1,10 @@
+---
+title: 'Shrooms'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Makes the player [trip](https://noita.wiki.gg/wiki/Status_Effects#Tripping) for a while.
+
+The tripping effect is not enough to cause a [Fungal Reality Shift](https://noita.wiki.gg/wiki/Fungal_Reality_Shift) by itself.

--- a/content/twitch/twitch-integration/shuffle.md
+++ b/content/twitch/twitch-integration/shuffle.md
@@ -1,0 +1,8 @@
+---
+title: 'Shuffle'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Makes all wands in the player's inventory [shuffle](https://noita.wiki.gg/wiki/Wands#Shuffle).

--- a/content/twitch/twitch-integration/shuffle_deck.md
+++ b/content/twitch/twitch-integration/shuffle_deck.md
@@ -1,0 +1,8 @@
+---
+title: 'Scrambled wands'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Randomises the position of spells in the player's wands.

--- a/content/twitch/twitch-integration/slime_squad.md
+++ b/content/twitch/twitch-integration/slime_squad.md
@@ -1,0 +1,7 @@
+---
+title: 'Slime Squad'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+

--- a/content/twitch/twitch-integration/spicy_perks.md
+++ b/content/twitch/twitch-integration/spicy_perks.md
@@ -1,0 +1,12 @@
+---
+title: 'Spicy perks'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Surrounds perks in the next Holy Mountain with lava, enclosed in glass.
+
+To take a perk, the player has to break the glass to get rid of the lava first.
+
+If a [fungal shift](https://noita.wiki.gg/wiki/Fungal_Reality_Shift) (e.g. from Tripping Balls) has removed lava, this option will likely be less dangerous.

--- a/content/twitch/twitch-integration/spiderman.md
+++ b/content/twitch/twitch-integration/spiderman.md
@@ -1,0 +1,10 @@
+---
+title: 'Spiderman'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Temporarily gives the player, and nearby enemies, the [Lukki Mutation](https://noita.wiki.gg/wiki/Lukki_Mutation) perk (spider legs).
+
+Often deadly with Lava Pit, since the player cannot levitate to escape.

--- a/content/twitch/twitch-integration/spiked_drink.md
+++ b/content/twitch/twitch-integration/spiked_drink.md
@@ -1,0 +1,12 @@
+---
+title: 'Spiked Drinks'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Adds random liquids to all of the player's flasks.
+
+Liquids such as polymorphine can be especially dangerous when the player doesn't notice (or forgets) that their flasks were spiked.
+
+Some liquids will also react inside the flask, ruining certain potions. If the player is relying on an acid flask as a method of killing the final boss, certain materials will turn the acid into flammable gas.

--- a/content/twitch/twitch-integration/stronk.md
+++ b/content/twitch/twitch-integration/stronk.md
@@ -1,0 +1,8 @@
+---
+title: 'Stronk'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Applies a [Glass Cannon](https://noita.wiki.gg/wiki/Glass_Cannon)-like effect for a while (without reducing HP). Makes explosive spells very dangerous.

--- a/content/twitch/twitch-integration/sugarrush.md
+++ b/content/twitch/twitch-integration/sugarrush.md
@@ -1,0 +1,8 @@
+---
+title: 'Sugar Rush'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+For the rest of the run, enemies will be more aggessive and will be able to see through walls.

--- a/content/twitch/twitch-integration/summon_spirits.md
+++ b/content/twitch/twitch-integration/summon_spirits.md
@@ -1,0 +1,12 @@
+---
+title: 'Summon Spirits'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Summons a [Fire Spirit](https://noita.wiki.gg/wiki/Liekki%C3%B6) and an [Ice Spirit](https://noita.wiki.gg/wiki/J%C3%A4%C3%A4ti%C3%B6).
+
+The fire spirit creates explosive gunpowder in the general area when damaged.
+
+The ice spirit is capable of [freeze melee](https://noita.wiki.gg/wiki/Damage_Types#Melee_damage) attacks.

--- a/content/twitch/twitch-integration/swapper_curse.md
+++ b/content/twitch/twitch-integration/swapper_curse.md
@@ -1,0 +1,10 @@
+---
+title: 'Swapper Curse'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Makes the player swap places with enemies near the cursor.
+
+Can swap the player into dangerous situations, e.g. if multiple enemies are in a group.

--- a/content/twitch/twitch-integration/swimming_pool.md
+++ b/content/twitch/twitch-integration/swimming_pool.md
@@ -1,0 +1,10 @@
+---
+title: 'Swimming Pool'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a [Sea of Water](https://noita.wiki.gg/wiki/Sea_of).
+
+Can be dangerous with Poisoned Water, or sources of electricity (e.g. Thunderstones).

--- a/content/twitch/twitch-integration/teleport_beacon.md
+++ b/content/twitch/twitch-integration/teleport_beacon.md
@@ -1,0 +1,27 @@
+---
+title: 'Teleport Beacon'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a "beacon" at the player's current position. If the player attempts to teleport, they are teleported back to the beacon instead.
+
+What is detected as "teleporting" is very broad, making this option quite disruptive. Any sudden movement over a certain amount is detected as a teleport, regardless of cause.
+
+Examples:
+
+Spells
+- [Teleport Bolt](https://noita.wiki.gg/wiki/Teleport_Bolt)
+- [Small Teleport Bolt](https://noita.wiki.gg/wiki/Teleport_Bolt)
+- [Return](https://noita.wiki.gg/wiki/Return)
+- [Swapper](https://noita.wiki.gg/wiki/Swapper)
+- [Circle of Displacement](https://noita.wiki.gg/wiki/Circle_of_Displacement)
+
+Perks
+- [Teleportitis](https://noita.wiki.gg/wiki/Teleportitis)
+- [Teleportitis Dodge](https://noita.wiki.gg/wiki/Teleportitis_Dodge)
+
+Other
+- Portals
+- [Swapper mage](https://noita.wiki.gg/wiki/Vaihdosmestari)

--- a/content/twitch/twitch-integration/teleport_rideshare.md
+++ b/content/twitch/twitch-integration/teleport_rideshare.md
@@ -1,0 +1,10 @@
+---
+title: 'Teleport Rideshare'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Teleports nearby enemies along with the player when they teleport. As with Teleport Beacon, suddenly moving a certain distance counts as "teleporting" regardless of cause.
+
+Dangerous with other effects that teleport the player, and especially with the Teleportitis perk: after being damaged by an enemy, the player will teleport away, bringing more enemies with them, which can damage the player further, and so on.

--- a/content/twitch/twitch-integration/the_swarm.md
+++ b/content/twitch/twitch-integration/the_swarm.md
@@ -1,0 +1,10 @@
+---
+title: 'The Swarm'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns some [fireflies](https://noita.wiki.gg/wiki/Tulik%C3%A4rp%C3%A4nen).
+
+As with other options that spawn enemies, this can be a dangerous combo with options that modify enemies (e.g. Derandomized Enemies, Derandomized Enemy Attacks, Weebpocalypse, Steve Gang).

--- a/content/twitch/twitch-integration/thunderstone_madness.md
+++ b/content/twitch/twitch-integration/thunderstone_madness.md
@@ -1,0 +1,8 @@
+---
+title: 'THUNDERSTONES!?!'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns multiple [electric rocks](https://noita.wiki.gg/wiki/Ukkoskivi) near the player. Dangerous near liquids. Can kill the player if they are submerged in liquid at the time.

--- a/content/twitch/twitch-integration/transmutation.md
+++ b/content/twitch/twitch-integration/transmutation.md
@@ -1,0 +1,8 @@
+---
+title: 'Transmutation'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Periodically turns a circle of material near the player into acid. Quite dangerous, especially in cramped areas.

--- a/content/twitch/twitch-integration/ukko_in_a_box.md
+++ b/content/twitch/twitch-integration/ukko_in_a_box.md
@@ -1,0 +1,12 @@
+---
+title: 'Ukko in a box'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Causes the next opened chest to contain an Ukko in addition to its original contents.
+
+If unprepared, the Ukko may damage or kill the player. Electricity from the attack can stun the player.
+
+If the player opens a chest underwater, they may be immediately killed by electricity flowing through the water.

--- a/content/twitch/twitch-integration/ultimate_killer.md
+++ b/content/twitch/twitch-integration/ultimate_killer.md
@@ -1,0 +1,10 @@
+---
+title: 'Ultimate Killer'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns a tiny [Horror Monster](https://noita.wiki.gg/wiki/Kauhuhirvi%C3%B6) that is friendly to the player.
+
+When killed, it generates a large explosion and an earthquake (and slime).

--- a/content/twitch/twitch-integration/void_circle.md
+++ b/content/twitch/twitch-integration/void_circle.md
@@ -1,0 +1,7 @@
+---
+title: 'Avoid the Void!™️'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+

--- a/content/twitch/twitch-integration/wand_mirage.md
+++ b/content/twitch/twitch-integration/wand_mirage.md
@@ -1,0 +1,8 @@
+---
+title: 'Wand Mirage'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Causes a wand that the player gets near to disappear. Each wand that the player has not picked up has a random chance to disappear, until one has disappeared.

--- a/content/twitch/twitch-integration/wand_replacement.md
+++ b/content/twitch/twitch-integration/wand_replacement.md
@@ -1,0 +1,12 @@
+---
+title: 'Replace wand'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Replaces one of the player's wands (not necessarily the one they are holding) with a randomly-generated one.
+
+If the player has a good wand (e.g. Teleport Bolt), this can make their run more difficult. If they don't (e.g. early in the game), it might give them a better wand.
+
+Can be dangerous (depending on which spells are randomly selected) if the player does not notice the wand being replaced.

--- a/content/twitch/twitch-integration/worm_can.md
+++ b/content/twitch/twitch-integration/worm_can.md
@@ -1,0 +1,10 @@
+---
+title: 'Can of Worms'
+date: 2024-07-01T02:12:57+12:00
+type: docs
+draft: false
+---
+
+Spawns 10 [tiny worms](https://noita.wiki.gg/wiki/Pikkumato).
+
+Worms deal melee damage, and can detonate explosives. They will not directly harm the player if the player has [Melee Immunity](https://noita.wiki.gg/wiki/Melee_Immunity).


### PR DESCRIPTION
Initial descriptions for most TI options. Still needs GIFs.
I've done some checks, but haven't thoroughly verified that all the descriptions are 100% correct.

Filenames are currently based on the original .lua files in `twitch_fragments/outcomes`, since I made a script to split everything into separate files from my original document. Names based on titles would probably make more sense.

Generated files in `public` are excluded - that should probably be in `.gitignore`.