### PR TITLE
Support width/height in video cards

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -23,3 +23,7 @@
 .rounded-card {
   border-radius: 1.5rem;
 }
+
+.hextra-card-image {
+  width: 100%;
+}

--- a/layouts/partials/shortcodes/card.html
+++ b/layouts/partials/shortcodes/card.html
@@ -45,6 +45,8 @@
       loop
       muted
       src="{{ $video | safeURL }}"
+      {{ with $width }}width="{{ . }}"{{ end }}
+      {{ with $height }}height="{{ . }}"{{ end }}
       {{ with $imageStyle }}style="{{ . | safeCSS }}"{{ end }}
     ></video>
   {{- end -}}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -5,8 +5,8 @@
 {{- $subtitle := .Get "subtitle" -}}
 {{- $image := .Get "image" -}}
 {{- $video := .Get "video" -}}
-{{- $width := 0 -}}
-{{- $height := 0 -}}
+{{- $width := .Get "width" | default 0 | int -}}
+{{- $height := .Get "height" | default 0 | int -}}
 {{- $imageStyle := .Get "imageStyle" -}}
 
 
@@ -38,6 +38,11 @@
       {{- $image = relURL (strings.TrimPrefix "/" $image) -}}
     {{- end -}}
   {{- end -}}
+{{- end -}}
+
+{{/* Fix dimensions during video load in Chrome */}}
+{{- if and $video $width $height -}}
+  {{- $imageStyle = printf "aspect-ratio: %d / %d; %s" $width $height $imageStyle | strings.TrimSuffix " " -}}
 {{- end -}}
 
 {{- partial "shortcodes/card" (dict


### PR DESCRIPTION
Adding dimensions to videos prevents the page from jumping around while they load.
Example:
```
{{< card title="Test" video="test.mp4" width="480" height="480" >}}
```